### PR TITLE
Update .lando.yml to reflect correct node version

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,7 +1,7 @@
 name: lando-redis-plugin
 services:
   node:
-    type: node:14
+    type: node:16
     build:
       - yarn install
     scanner: false

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,9 +14,9 @@ At the very least you will need to have the following installed:
 * [Lando 3.5.0+](https://docs.lando.dev/basics/installation.html), preferably installed [from source](https://docs.lando.dev/basics/installation.html#from-source).
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 
-While not a hard requirement it's also probably a good idea to install both `node` 14 and `yarn`
+While not a hard requirement it's also probably a good idea to install both `node` 16 and `yarn`
 
-* [Node 14](https://nodejs.org/dist/latest-v14.x/)
+* [Node 16](https://nodejs.org/dist/latest-v16.x/)
 * [Yarn](https://classic.yarnpkg.com/lang/en/docs/install)
 
 ## Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ mkdir -p ~/.lando/plugins
 # Install plugin
 # NOTE: Modify the "yarn add @lando/redis" line to install a particular version eg
 # yarn add @lando/redis@0.5.2
-docker run --rm -it -v ${HOME}/.lando/plugins:/plugins -w /tmp node:14-alpine sh -c \
+docker run --rm -it -v ${HOME}/.lando/plugins:/plugins -w /tmp node:16-alpine sh -c \
   "yarn init -y \
   && yarn add @lando/redis --production --flat --no-default-rc --no-lockfile --link-duplicates \
   && yarn install --production --cwd /tmp/node_modules/@lando/redis \


### PR DESCRIPTION
Updates .lando.yml to use node 16 to match [.node-version](https://github.com/lando/redis/blob/main/.node-version), allowing the dependencies to be installed.

![image](https://user-images.githubusercontent.com/7288499/229814857-2800a80b-ca77-419d-99dc-fbd6851ffa76.png)
