### PR TITLE
Update config.md with default password

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -15,7 +15,7 @@ services:
     type: redis:5
     persist: false
     portforward: false
-    password: ''
+    password: 'pantheon'
     config:
       server: SEE BELOW
 ```


### PR DESCRIPTION
Some of the issues seem to be related to missing update to the documentation of the default config for redis, as introduced here https://github.com/lando/pantheon/issues/147